### PR TITLE
Add easycheck and perftester

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [unittest](https://docs.python.org/3/library/unittest.html) - (Python standard library) Unit testing framework.
 - [Ward](https://github.com/darrenburns/ward) - is a modern test framework for Python with a focus on productivity and readability.
 - [xdoctest](https://github.com/Erotemic/xdoctest) - A rewrite of Python's builtin doctest module (with pytest plugin integration) with AST instead of REGEX.
-- [perftester](https://github.com/nyggus/perftester) - A lightweight framework for performance testing of Pyuthon functions; aloows for testing of performance in terms of execution time and memory usage.
+- [perftester](https://github.com/nyggus/perftester) - A lightweight framework for performance testing of Python functions; allows for testing of performance in terms of execution time and memory usage.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Collection of awesome Python resources for testing and generating test data.
 
 ## Assertions
 
+- [easycheck](https://github.com/nyggus/easycheck) - A collection of assertion-like functions to be used in code, where assertion themselves should be avoided; `easycheck` includes also function aliases to be used in unit testing.
 - [dirty-equals](https://github.com/samuelcolvin/dirty-equals) - A python library that (mis)uses the `__eq__` method to make python code (generally unit tests) more declarative and therefore easier to read and write.
 - [Precisely](https://github.com/mwilliamson/python-precisely) - allows you to write precise assertions so you only test the behaviour you're really interested in.
 - [PyHamcrest](https://github.com/hamcrest/PyHamcrest) - is a framework for writing matcher objects, allowing you to declaratively define "match" rules.
 - [pytest_cache_assert](https://github.com/kyleking/pytest_cache_assert) - Cache assertion data to simplify regression testing of complex serializable data.
 - [sure](https://github.com/gabrielfalcao/sure) - An idiomatic assertion toolkit with human-friendly failure messages, inspired by RSpec Expectations and should.js.
-- [easycheck](https://github.com/nyggus/easycheck) - A collection of assertion-like functions to be used in code, where assertion themselves should be avoided; `easycheck` includes also function aliases to be used in unit testing.
 
 ## Behavior-driven Development
 
@@ -154,13 +154,13 @@ Collection of awesome Python resources for testing and generating test data.
 - [doctest](https://docs.python.org/3/library/doctest.html) - (Python standard library) The doctest module searches for pieces of text that look like interactive Python sessions, and then executes those sessions to verify that they work exactly as shown.
 - [hammett](https://github.com/boxed/hammett) - Fast python test runner, compatible with a subset of pytest.
 - [nose2](https://github.com/nose-devs/nose2) - The successor to `nose`, based on `unittest2`.
+- [perftester](https://github.com/nyggus/perftester) - A lightweight framework for performance testing of Python functions; allows for testing of performance in terms of execution time and memory usage.
 - [pytest](https://docs.pytest.org/en/latest) - A mature full-featured Python testing tool.
 - [Robot Framework](https://github.com/robotframework/robotframework) - A generic test automation framework.
 - [testbook](https://github.com/nteract/testbook) - A unit testing framework extension for testing code in Jupyter Notebooks.
 - [unittest](https://docs.python.org/3/library/unittest.html) - (Python standard library) Unit testing framework.
 - [Ward](https://github.com/darrenburns/ward) - is a modern test framework for Python with a focus on productivity and readability.
 - [xdoctest](https://github.com/Erotemic/xdoctest) - A rewrite of Python's builtin doctest module (with pytest plugin integration) with AST instead of REGEX.
-- [perftester](https://github.com/nyggus/perftester) - A lightweight framework for performance testing of Python functions; allows for testing of performance in terms of execution time and memory usage.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [PyHamcrest](https://github.com/hamcrest/PyHamcrest) - is a framework for writing matcher objects, allowing you to declaratively define "match" rules.
 - [pytest_cache_assert](https://github.com/kyleking/pytest_cache_assert) - Cache assertion data to simplify regression testing of complex serializable data.
 - [sure](https://github.com/gabrielfalcao/sure) - An idiomatic assertion toolkit with human-friendly failure messages, inspired by RSpec Expectations and should.js.
+- [easycheck](https://github.com/nyggus/easycheck) - A collection of assertion-like functions to be used in code, where assertion themselves should be avoided; `easycheck` includes also function aliases to be used in unit testing.
 
 ## Behavior-driven Development
 
@@ -159,6 +160,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [unittest](https://docs.python.org/3/library/unittest.html) - (Python standard library) Unit testing framework.
 - [Ward](https://github.com/darrenburns/ward) - is a modern test framework for Python with a focus on productivity and readability.
 - [xdoctest](https://github.com/Erotemic/xdoctest) - A rewrite of Python's builtin doctest module (with pytest plugin integration) with AST instead of REGEX.
+- [perftester](https://github.com/nyggus/perftester) - A lightweight framework for performance testing of Pyuthon functions; aloows for testing of performance in terms of execution time and memory usage.
 
 ## Tools
 


### PR DESCRIPTION
Assertions should be avoided in production code, and hence easycheck was proposed. It offers a number of functions that allow for checking various conditions when one would feel like using the assert statement. It also offers aliases to be used in testing; e.g., `check_if` (`assert_if`), `check_if_not` (`assert_if_not`), `check_if_isclose` (`assert_if_isclose`), `check_type` (`assert_type`), and the like.
The `perftester` package aims to allow for performance testing of Python functions; performance here means both execution time and memory usage. The package can be used inside `pytest`, but mainly as a separate testing framework. As far as I know, it is the only performance testing framework for Python functions. It also allows for benchmarking functions, in terms of time and memory. (Benchmarking is included to enable the user to define limits for performance tests.)