### PR TITLE
Add D-MemFS: in-process virtual filesystem for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [Mockintosh](https://github.com/up9inc/mockintosh) - aims to provide usual HTTP mock service functionality with small resource footprint, making it friendly for microservice applications.
 - [moto](https://github.com/spulec/moto) - allows you to easily mock out tests based on AWS infrastructure.
 - [Pretend](https://github.com/alex/pretend) - is a library to make stubbing with Python easier.
+- [pyfakefs](https://github.com/pytest-dev/pyfakefs) - A fake file system that mocks the Python file system modules.
 - [responses](https://github.com/getsentry/responses) - A utility library for mocking out the requests Python library.
 - [time-machine](https://github.com/adamchainz/time-machine) - Travel through time in your tests.
 - [trustme](https://github.com/python-trio/trustme) - gives you a fake certificate authority (CA) that you can use to generate fake TLS certs to use in your tests.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Collection of awesome Python resources for testing and generating test data.
 
 - [Aioresponses](https://github.com/pnuckowski/aioresponses) - is a helper for mock/fake web requests in python aiohttp package.
 - [Cornell](https://github.com/hiredscorelabs/cornell) - record & replay mock server.
+- [D-MemFS](https://github.com/nightmarewalker/D-MemFS) - Zero-dependency in-memory virtual filesystem with hard quotas. Provides an explicit, isolated instance instead of patching global state.
 - [doublex](https://pypi.org/project/doublex) - Powerful test doubles framework for Python.
 - [Flexmock](https://github.com/flexmock/flexmock) - is a testing library for Python that makes it easy to create mocks, stubs and fakes.
 - [freezegun](https://github.com/spulec/freezegun) - Travel through time by mocking the datetime module.


### PR DESCRIPTION
## Description
Hello! I'd like to propose adding **D-MemFS** to the **Mocks** section (alongside `pyfakefs`).

While `pyfakefs` is excellent for patching global `os`/`open()` state, D-MemFS serves a different architectural need: it provides an explicit, isolated filesystem instance that you pass around via dependency injection. This means no monkey-patching and zero side effects on other code.

* **Full FS Semantics**: Hierarchical directories, hard quota enforcement, and file-level RW locking.
* **Concurrency Ready**: Fully thread-safe, including support for free-threaded Python 3.13 (`PYTHON_GIL=0`).
* **Zero Dependencies**: Relies purely on the Python standard library.
* **Proven Stability**: 369 tests, 97% coverage, tested across 3 OS × 3 Python versions in CI.
* **Community Validated**: Discussed on [r/Python](https://www.reddit.com/r/Python/comments/1rrqr8z/i_built_an_inmemory_virtual_filesystem_for_python/) with positive reception.

I believe it provides a valuable, explicit alternative for testing I/O-heavy code. Thank you for maintaining this awesome list!

## Summary by Sourcery

Documentation:
- Document D-MemFS as an in-memory virtual filesystem mock in the README mocks section.