### PR TITLE
Add pytest-test-observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ Collection of awesome Python resources for testing and generating test data.
 - [pytest-databases](https://github.com/litestar-org/pytest-databases) - Reusable database fixtures for any and all databases.
 - [pytestify](https://github.com/dannysepler/pytestify) - Automatically convert unittests to pytest.
 - [pytest-mock-generator](https://github.com/pksol/pytest-mock-generator) - A pytest fixture wrapper for `mock_autogen`.
-- [teyit](https://github.com/isidentical/teyit) - A static analyzer and a refactoring tool to rewrite your unittest assertions in the right way.
 - [pytest-test-observer](https://github.com/shakhov-dmitrii/pytest-test-observer) - A pytest plugin that ships per-test results to ClickHouse for trend analysis, flakiness tracking, and CI observability.
+- [teyit](https://github.com/isidentical/teyit) - A static analyzer and a refactoring tool to rewrite your unittest assertions in the right way.
 
 ## UI Testing
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [pytestify](https://github.com/dannysepler/pytestify) - Automatically convert unittests to pytest.
 - [pytest-mock-generator](https://github.com/pksol/pytest-mock-generator) - A pytest fixture wrapper for `mock_autogen`.
 - [teyit](https://github.com/isidentical/teyit) - A static analyzer and a refactoring tool to rewrite your unittest assertions in the right way.
+- [pytest-test-observer](https://github.com/shakhov-dmitrii/pytest-test-observer) - A pytest plugin that ships per-test results to ClickHouse for trend analysis, flakiness tracking, and CI observability.
 
 ## UI Testing
 


### PR DESCRIPTION
Adding [pytest-test-observer](https://github.com/shakhov-dmitrii/pytest-test-observer) to the Tools section.

pytest-test-observer is a fully-free pytest plugin. 
The plugin is easy to configure and helps significantly improve test observability without using a TMS or other paid solutions.
Key features:
- Automatic CI detection
- Allure report support
- Basic Grafana configuration provided out of the box
- No impact on pytest execution
- No additional overhead if export to ClickHouse is disabled
- Integrates with pytest
- MIT license

## Summary by Sourcery

Document a new pytest plugin in the testing tools list.

New Features:
- Add pytest-test-observer to the tools section as a recommended pytest plugin for exporting per-test results to ClickHouse.

Documentation:
- Update README to describe pytest-test-observer and its capabilities for test observability and CI analytics.