### PR TITLE
Add secure-log2test and pytest-conversational

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [perftester](https://github.com/nyggus/perftester) - A lightweight framework for performance testing of Python functions; allows for testing of performance in terms of execution time and memory usage.
 - [promptimize](https://github.com/preset-io/promptimize) - a prompt engineering evaluation and testing toolkit. It accelerates and provides structure around prompt engineering at scale with confidence, bringing some of the ideas behind test-driven development (TDD) to engineering prompts.
 - [pytest](https://docs.pytest.org/en/latest) - A mature full-featured Python testing tool.
+- [pytest-conversational](https://github.com/golikovichev/pytest-conversational) - A pytest plugin for testing rule-based chatbots and conversational UIs through multi-turn dialogue assertions, with no LLM dependency.
 - [rut](https://github.com/schettino72/rut) - A modern and fully-featured test runner for Python's unittest framework (not `pytest`), with simplicity as a core design goal.
 - [Robot Framework](https://github.com/robotframework/robotframework) - A generic test automation framework.
 - [Sphinx-testify](https://github.com/BasicWolf/sphinx-testify) - Testified documentation means that the documentation source references test results, and these references are verified during the build process. As a result, we can keep every paragraph even every sentence of the documentation aligned with the code, as long as there is a test that "testifies" the described behaviour.
@@ -249,6 +250,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [pytestify](https://github.com/dannysepler/pytestify) - Automatically convert unittests to pytest.
 - [pytest-mock-generator](https://github.com/pksol/pytest-mock-generator) - A pytest fixture wrapper for `mock_autogen`.
 - [pytest-test-observer](https://github.com/shakhov-dmitrii/pytest-test-observer) - A pytest plugin that ships per-test results to ClickHouse for trend analysis, flakiness tracking, and CI observability.
+- [secure-log2test](https://github.com/golikovichev/secure-log2test) - A CLI tool that converts Kibana JSON log exports into runnable pytest regression suites, with Pydantic-based redaction of authorization headers and other secrets at parse time.
 - [teyit](https://github.com/isidentical/teyit) - A static analyzer and a refactoring tool to rewrite your unittest assertions in the right way.
 
 ## UI Testing


### PR DESCRIPTION
Adding two more pytest-related Python testing tools, both currently active on PyPI:

- `secure-log2test` to **Tools** section (between `pytest-test-observer` and `teyit`): a CLI that converts Kibana JSON log exports into runnable pytest regression suites with redaction of authorization headers and other secrets at parse time.
- `pytest-conversational` to **Testing Frameworks** section (between `pytest` and `rut`): a pytest plugin for testing rule-based chatbots and conversational UIs through multi-turn dialogue assertions, with no LLM dependency.

Both entries placed alphabetically within their section. Same author as #85 (postman2pytest).

## Summary by Sourcery

Add new pytest-related tools to the README testing resources list.

New Features:
- Document pytest-conversational as a pytest plugin for testing rule-based chatbots and conversational UIs via multi-turn dialogue assertions.
- Document secure-log2test as a CLI for converting Kibana JSON logs into pytest regression test suites with built-in secret redaction.