### PR TITLE
Add pywrkr

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [Grizzly](https://github.com/biometria-se/grizzly) - is a framework to be able to easily define load scenarios, and is mainly built on-top of Locust and Behave.
 - [Locust](https://github.com/locustio/locust) - Scalable user load testing tool written in Python.
 - [pynonymizer](https://github.com/jerometwell/pynonymizer) - is a universal tool for translating sensitive production database dumps into anonymized copies.
-- [pywrkr](https://github.com/kurok/pywrkr) - HTTP benchmarking CLI inspired by wrk and Apache ab, with latency percentiles, virtual-user simulation, constant-rate and traffic-profile load shaping, HAR import, and pass/fail SLO thresholds for CI.
+- [pywrkr](https://github.com/kurok/pywrkr) - HTTP benchmarking CLI inspired by wrk and ApacheBench (ab), with latency percentiles, virtual-user simulation, constant-rate and traffic-profile load shaping, HAR import, and pass/fail SLO thresholds for CI.
 
 ## Memory Management
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Collection of awesome Python resources for testing and generating test data.
 - [Grizzly](https://github.com/biometria-se/grizzly) - is a framework to be able to easily define load scenarios, and is mainly built on-top of Locust and Behave.
 - [Locust](https://github.com/locustio/locust) - Scalable user load testing tool written in Python.
 - [pynonymizer](https://github.com/jerometwell/pynonymizer) - is a universal tool for translating sensitive production database dumps into anonymized copies.
+- [pywrkr](https://github.com/kurok/pywrkr) - HTTP benchmarking CLI inspired by wrk and Apache ab, with latency percentiles, virtual-user simulation, constant-rate and traffic-profile load shaping, HAR import, and pass/fail SLO thresholds for CI.
 
 ## Memory Management
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,2 +1,6 @@
 [default]
 extend-ignore-identifiers-re = ["mis", "Packt"]
+
+[default.extend-words]
+# "wrk" (github.com/wg/wrk) is a tool name, not a typo for "work"
+wrk = "wrk"


### PR DESCRIPTION
Adds [pywrkr](https://github.com/kurok/pywrkr) to the **Load Testing** section (alphabetically, after `pynonymizer`).

pywrkr is a pure-Python HTTP benchmarking CLI (MIT, [on PyPI](https://pypi.org/project/pywrkr/)) inspired by wrk and Apache ab: latency percentiles (p50–p99.99), virtual-user simulation, constant-rate and traffic-profile load shaping, HAR import, and pass/fail SLO thresholds for CI.

## Summary by Sourcery

Documentation:
- Add pywrkr to the Load Testing section as an HTTP benchmarking CLI option.