### PR TITLE
Add Crucible to Mutation Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Collection of awesome Python resources for testing and generating test data.
 
 - [bough](https://github.com/CodeEnPlace/bough) - Bough is a polyglot incremental mutation tester.
 - [Cosmic Ray](https://github.com/sixty-north/cosmic-ray) - makes small changes to your source code, running your test suite for each one.
+- [Crucible](https://github.com/Jott2121/crucible) - Adversarial test-hardening for AI-written code, built on mutmut. A Tester agent writes tests, mutation testing names the survivors, and a Critic agent kills exactly those.
 - [Mutatest](https://github.com/EvanKepner/mutatest) - Python mutation testing.
 - [Mutmut](https://github.com/boxed/mutmut) - is a mutation testing system for Python, with a strong focus on ease of use.
 - [MutPy](https://github.com/mutpy/mutpy) - MutPy is a mutation testing tool for Python 3.x source code


### PR DESCRIPTION
Adds [Crucible](https://github.com/Jott2121/crucible) to the Mutation Testing section (alphabetical, between Cosmic Ray and Mutatest).

**What it is:** adversarial test-hardening for AI-written code, built on top of mutmut rather than competing with it. A Tester agent writes tests, mutation testing names the surviving mutants, and a Critic agent is handed those named survivors and writes tests to kill exactly them. Every verdict is mechanical — pytest kills the mutant or it doesn't — so no model ever grades model output.

**Why it belongs on this list:** the coverage/fault-detection gap gets systematically worse when a model writes both the code and its tests, and mutation testing is the only cheap way to see it. On a real module with 7 passing tests and 97% line coverage, 25 of 71 injected defects survived.

- MIT licensed, Python + pytest, `mutmut` pinned to 3.6.0
- The diagnose (`crucible score`) calls no model and needs no API key
- Also ships as a GitHub Action that comments the mutation score on a PR
- 332 tests; dogfooded — it runs its own mutation gate on itself (982 mutants, 977 killed, 5 documented survivors)
- Includes a pre-registered experiment with a published null result

Happy to reword the entry or move it if you'd prefer a different section or a shorter description.

## Summary by Sourcery

Documentation:
- Document Crucible as an adversarial test-hardening tool for AI-written code in the mutation testing section of the README.