### PR TITLE
Add greenproof to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Collection of awesome Python resources for testing and generating test data.
 
 - [CrossHair](https://github.com/pschanely/CrossHair) - An analysis tool for Python that blurs the line between testing and type systems.
 - [ghostwriter](https://hypothesis.readthedocs.io/en/latest/ghostwriter.html) - Writing tests with Hypothesis frees you from the tedium of deciding on and writing out specific inputs to test.
+- [greenproof](https://github.com/zxyasfas/greenproof) - Checks whether a coding agent's green pytest run was earned, not manufactured by editing the tests. Snapshots the original tests, then reruns the agent's current code against them to see if it still passes.
 - [importlab](https://github.com/google/importlab) - A library that automatically infers dependencies for Python files. Importlab's main use case is to work with static analysis tools that process one file at a time, ensuring that a file's dependencies are analysed before it is.
 - [Klara](https://github.com/usagitoneko97/klara) - Static analysis tools to automatic generate test case, based on SMT (z3) solver, with a powerful ast level inference system.
 - [logot](https://github.com/etianen/logot) - Test whether your code is logging correctly.


### PR DESCRIPTION
greenproof re-runs an agent's current code against the original tests (from before the agent touched anything) to check whether a claimed-green suite actually holds, or whether it only went green because the tests changed. Pytest-only, no network calls.

## Summary by Sourcery

Documentation:
- Document the greenproof tool in the testing tools list, describing its purpose of validating that green pytest runs are due to code changes rather than modified tests.