### PR TITLE
Add Sabot to LLM & MCP Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Collection of awesome Python resources for testing and generating test data.
 ## LLM & MCP Testing
 
 - [mcp-server-fuzzer](https://github.com/Agent-Hellboy/mcp-server-fuzzer) - A comprehensive fuzzing tool designed specifically for testing Model Context Protocol (MCP) servers. It supports both tool argument fuzzing and protocol type fuzzing across multiple transport protocols.
+- [Sabot](https://github.com/Jott2121/sabot) - Plants controlled faults inside running multi-agent pipelines (LangGraph, CrewAI, AutoGen) and scores whether each pipeline's own reviewer and guardrail stages detect them. Pre-registered spec, deterministic adjudication, published raw traces.
 - [Tenro](https://github.com/tenro-ai/tenro-python) - An open-source, provider-agnostic testing framework for AI agents that integrates with pytest. It simulates LLM and tool calls to test edge cases, failure paths, and agent logic without live API calls.
 
 ## Load Testing


### PR DESCRIPTION
Adding [Sabot](https://github.com/Jott2121/sabot) under **LLM & MCP Testing**, placed alphabetically between `mcp-server-fuzzer` and `Tenro`.

**What it does that the neighbouring entries don't:** Tenro and mcp-server-fuzzer exercise agents from the outside. Sabot injects one controlled fault *inside* a running multi-agent pipeline (a corrupted tool result, a falsified success report, an altered inter-agent message, a silent model downgrade, stale context, a silent no-op) and scores whether the pipeline's **own** reviewer and guardrail stages catch it — no external monitor in the detection path.

Why it may be useful to this list's readers: measured across LangGraph, CrewAI and AutoGen/Magentic-One, the median own-check detection rate was 16.7%, and the most common outcome was a correct final answer with nothing ever flagging the fault.

- Apache-2.0 harness, CC BY 4.0 spec and results
- Specification, seeds and adjudication anchors registered publicly *before* any scored run
- Full raw trace corpus published, so every score is recomputable offline with stdlib Python and no API key: `python3 scripts/score_wave2.py --seeds-file ../seeds/wave2.json` reproduces all 189 published rows byte-identically
- Archived with a DOI: https://doi.org/10.5281/zenodo.21539796

Disclosure: I'm the author. You merged my other project (Crucible) into Mutation Testing a couple weeks ago, happy to adjust the wording or drop this if it's out of scope for the section.