### PR TITLE
Add 9lives to UI Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Collection of awesome Python resources for testing and generating test data.
 
 ## UI Testing
 
+- [9lives](https://github.com/Quality-Max/9lives) - Self-healing CLI for UI tests: runs a failing pytest + Selenium spec, repairs the drifted locator offline, re-runs it, and shows a diff before applying. Refuses to rewrite assertions, so real regressions stay visible.
 - [Agent QA](https://github.com/vostride/agent-qa) - A Node-based, open-source, self-improving QA agent that can exercise Python web applications externally through natural-language browser tests, persistent testing context, and self-healing tests.
 - [aria-testing](https://github.com/t-strings/aria-testing) - Accessibility-focused DOM testing library for tdom, built with modern Python 3.14+.
 - [Flybirds](https://github.com/ctripcorp/flybirds) - is a front-end UI automation test framework based on BDD mode, providing a series of out-of-the-box tools and complete documentation.


### PR DESCRIPTION
## Summary

Adds [9lives](https://github.com/Quality-Max/9lives) to the UI Testing section — an MIT-licensed Python CLI (`pip install 9lives`, Python >= 3.10) that repairs UI tests whose locators have drifted.

For Python users it runs your own pytest + Selenium:

```
9l heal tests/test_checkout.py
```

It runs the failing spec, classifies the failure, repairs the selector offline from the failure-time page snapshot (no LLM, no network, no account required), re-runs it, and shows a unified diff before applying anything.

It deliberately refuses to rewrite failing **assertions** — a changed assertion means the application's behaviour changed, not that a selector moved — so it will not mask a real regression to force a green run.

- PyPI: https://pypi.org/project/9lives/
- Source: https://github.com/Quality-Max/9lives (MIT)

Entry placed first in the UI Testing section, ahead of `Agent QA`, per digit-before-letter ordering. Branch is rebased on current `main`, so the diff is a single line.

## Context

This replaces #104, which you closed on 2026-08-03. That one proposed QualityMax, a commercial hosted platform. Reading your reasoning on #72 ("I won't include commercial SAAS applications in this list"), that was the wrong submission for this list — so this proposes our open-source package instead.

If it is still not a fit, a one-line "no" is genuinely useful and I won't resubmit.

Disclosure: 9lives is maintained by the QualityMax team; I'm submitting on their behalf.

## Summary by Sourcery

New Features:
- Add 9lives to the UI Testing resources list as an open-source self-healing CLI for pytest and Selenium tests.